### PR TITLE
Add SwiftUI search bar view

### DIFF
--- a/SearchBarView.swift
+++ b/SearchBarView.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+struct SearchBarView: View {
+    @State private var searchText: String = ""
+
+    var body: some View {
+        HStack(spacing: 16) {
+            Image(systemName: "magnifyingglass")
+                .foregroundColor(.secondary)
+
+            TextField("Search", text: $searchText)
+                .textFieldStyle(.plain)
+                .textInputAutocapitalization(.none)
+                .disableAutocorrection(true)
+
+            Spacer(minLength: 0)
+
+            Image(systemName: "square.and.pencil")
+                .foregroundColor(.blue)
+
+            Image(systemName: "notification")
+                .foregroundColor(.orange)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .background(
+            RoundedRectangle(cornerRadius: 20, style: .continuous)
+                .fill(Color(.systemGray6))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 20, style: .continuous)
+                .stroke(Color(.systemGray4))
+        )
+        .padding(.horizontal)
+    }
+}
+
+struct SearchBarView_Previews: PreviewProvider {
+    static var previews: some View {
+        SearchBarView()
+            .padding()
+            .previewLayout(.sizeThatFits)
+    }
+}


### PR DESCRIPTION
## Summary
- create a reusable `SearchBarView` SwiftUI component that matches the requested layout
- add a preview configuration to visualize the search bar styling

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68da761b4ff8832eaa6f559ef46fbd96