### PR TITLE
Add AdsPostView with sponsored content layout

### DIFF
--- a/AdsPostView.swift
+++ b/AdsPostView.swift
@@ -1,0 +1,152 @@
+import SwiftUI
+
+struct AdsPost: Identifiable {
+    let id = UUID()
+    let advertiserName: String
+    let advertiserAvatarURL: URL?
+    let contentText: String
+    let imageURL: URL?
+    let actionTitle: String
+}
+
+struct AdsPostView: View {
+    let post: AdsPost
+    var action: () -> Void = {}
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            header
+            content
+            footer
+        }
+        .padding(16)
+        .background(
+            RoundedRectangle(cornerRadius: 20, style: .continuous)
+                .fill(Color(.systemBackground))
+                .shadow(color: .black.opacity(0.04), radius: 12, x: 0, y: 4)
+        )
+    }
+
+    private var header: some View {
+        HStack(alignment: .center, spacing: 12) {
+            AsyncImage(url: post.advertiserAvatarURL, transaction: Transaction(animation: .easeInOut)) { phase in
+                switch phase {
+                case .success(let image):
+                    image
+                        .resizable()
+                        .scaledToFill()
+                case .empty:
+                    ProgressView()
+                        .tint(.secondary)
+                case .failure:
+                    Image(systemName: "briefcase.circle")
+                        .resizable()
+                        .scaledToFit()
+                        .symbolRenderingMode(.hierarchical)
+                        .foregroundStyle(.secondary)
+                @unknown default:
+                    EmptyView()
+                }
+            }
+            .frame(width: 48, height: 48)
+            .background(Color(.systemGray5))
+            .clipShape(Circle())
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(post.advertiserName)
+                    .font(.headline)
+                    .foregroundStyle(Color.primary)
+
+                Text("Sponsored")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+        }
+    }
+
+    private var content: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(post.contentText)
+                .font(.body)
+                .foregroundStyle(Color.primary)
+
+            if let imageURL = post.imageURL {
+                RemoteAdMediaView(url: imageURL, height: 220, cornerRadius: 16)
+            }
+        }
+    }
+
+    private var footer: some View {
+        Button(action: action) {
+            Text(post.actionTitle)
+                .font(.subheadline)
+                .fontWeight(.semibold)
+                .foregroundStyle(.white)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 12)
+                .background(
+                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        .fill(Color.blue)
+                )
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+private struct RemoteAdMediaView: View {
+    let url: URL
+    var height: CGFloat?
+    var cornerRadius: CGFloat = 0
+
+    var body: some View {
+        AsyncImage(url: url, transaction: Transaction(animation: .easeInOut)) { phase in
+            switch phase {
+            case .success(let image):
+                image
+                    .resizable()
+                    .scaledToFill()
+            case .empty:
+                placeholderView(symbolName: "photo")
+            case .failure:
+                placeholderView(symbolName: "exclamationmark.triangle")
+            @unknown default:
+                placeholderView(symbolName: "photo")
+            }
+        }
+        .frame(height: height)
+        .frame(maxWidth: .infinity)
+        .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+        .clipped()
+    }
+
+    @ViewBuilder
+    private func placeholderView(symbolName: String) -> some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                .fill(Color(.systemGray6))
+
+            Image(systemName: symbolName)
+                .font(.title2)
+                .foregroundStyle(.secondary)
+        }
+    }
+}
+
+struct AdsPostView_Previews: PreviewProvider {
+    static var previews: some View {
+        AdsPostView(
+            post: AdsPost(
+                advertiserName: "SwiftUI Courses",
+                advertiserAvatarURL: URL(string: "https://images.unsplash.com/photo-1524504388940-b1c1722653e1?w=200"),
+                contentText: "Level up your SwiftUI skills with our hands-on courses and real-world projects.",
+                imageURL: URL(string: "https://images.unsplash.com/photo-1521737604893-d14cc237f11d?w=1200"),
+                actionTitle: "Learn More"
+            )
+        )
+        .padding()
+        .previewLayout(.sizeThatFits)
+        .background(Color(.systemGroupedBackground))
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated `AdsPostView` to render a sponsored post section with header, content, and footer button
- include data model and async image handling for advertiser avatar and media content

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68db68bd1944832e913b1db939daa491