### PR TITLE
Ensure search placeholder is visible on blue background

### DIFF
--- a/Views/Components/Search/SearchBarView.swift
+++ b/Views/Components/Search/SearchBarView.swift
@@ -8,11 +8,18 @@ struct SearchBarView: View {
             Image(systemName: "magnifyingglass")
                 .foregroundStyle(.white)
 
-            TextField("Search", text: $searchText)
-                .textFieldStyle(.plain)
-                .textInputAutocapitalization(.none)
-                .disableAutocorrection(true)
-                .foregroundStyle(.white.opacity(0.8))
+            ZStack(alignment: .leading) {
+                if searchText.isEmpty {
+                    Text("Search")
+                        .foregroundStyle(.white.opacity(0.7))
+                }
+
+                TextField("", text: $searchText)
+                    .textFieldStyle(.plain)
+                    .textInputAutocapitalization(.none)
+                    .disableAutocorrection(true)
+                    .foregroundStyle(.white.opacity(0.8))
+            }
 
             Spacer(minLength: 0)
 


### PR DESCRIPTION
## Summary
- replace the TextField placeholder with a custom overlay so the text renders in white
- ensure the search hint text stays visible when the search bar background is blue

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68de48dd09c0832e8d7b3aaf82b39389