### PR TITLE
Replace UIKit grays with SwiftUI Color extensions

### DIFF
--- a/Extensions/Color+SystemGray.swift
+++ b/Extensions/Color+SystemGray.swift
@@ -1,0 +1,7 @@
+import SwiftUI
+
+extension Color {
+    static let systemGray3 = Color(red: 199.0 / 255.0, green: 199.0 / 255.0, blue: 204.0 / 255.0)
+    static let systemGray5 = Color(red: 229.0 / 255.0, green: 229.0 / 255.0, blue: 234.0 / 255.0)
+    static let systemGray6 = Color(red: 242.0 / 255.0, green: 242.0 / 255.0, blue: 247.0 / 255.0)
+}

--- a/Views/Components/Ads/AdsPostView.swift
+++ b/Views/Components/Ads/AdsPostView.swift
@@ -20,7 +20,7 @@ struct AdsPostView: View {
 
     private var header: some View {
         HStack(spacing: 12) {
-            AsyncImage(url: post.advertiserAvatarURL, transaction: Transaction(animation: .easeInOut)) { phase in
+        AsyncImage(url: post.advertiserAvatarURL, transaction: Transaction(animation: .easeInOut)) { phase in
                 switch phase {
                 case .success(let image):
                     image
@@ -38,10 +38,10 @@ struct AdsPostView: View {
                 @unknown default:
                     EmptyView()
                 }
-            }
-            .frame(width: 48, height: 48)
-            .background(Color(.systemGray5))
-            .clipShape(Circle())
+        }
+        .frame(width: 48, height: 48)
+        .background(Color.systemGray5)
+        .clipShape(Circle())
 
             VStack(alignment: .leading, spacing: 4) {
                 Text(post.advertiserName)
@@ -116,7 +116,7 @@ private struct RemoteAdMediaView: View {
     private func placeholderView(symbolName: String) -> some View {
         ZStack {
             RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                .fill(Color(.systemGray6))
+                .fill(Color.systemGray6)
 
             Image(systemName: symbolName)
                 .font(.title2)

--- a/Views/Components/CreateStory/CreateMyStoryView.swift
+++ b/Views/Components/CreateStory/CreateMyStoryView.swift
@@ -22,16 +22,16 @@ struct CreateMyStoryView: View {
                         Image(systemName: "person.crop.circle.fill")
                             .resizable()
                             .scaledToFill()
-                            .foregroundStyle(Color(.systemGray3))
+                            .foregroundStyle(Color.systemGray3)
                     @unknown default:
                         Image(systemName: "person.crop.circle.fill")
                             .resizable()
                             .scaledToFill()
-                            .foregroundStyle(Color(.systemGray3))
+                            .foregroundStyle(Color.systemGray3)
                     }
                 }
                 .frame(width: 48, height: 48)
-                .background(Color(.systemGray5))
+                .background(Color.systemGray5)
                 .clipShape(Circle())
 
                 Text(placeholder)
@@ -41,7 +41,7 @@ struct CreateMyStoryView: View {
                     .padding(.horizontal, 16)
                     .background(
                         RoundedRectangle(cornerRadius: 14, style: .continuous)
-                            .fill(Color(.systemGray6))
+                            .fill(Color.systemGray6)
                     )
             }
 
@@ -101,7 +101,7 @@ private struct CreateStoryActionButton: View {
             .padding(.vertical, 4)
             .background(
                 RoundedRectangle(cornerRadius: 12, style: .continuous)
-                    .fill(Color(.systemGray5))
+                    .fill(Color.systemGray5)
             )
         }
         .buttonStyle(.plain)

--- a/Views/Components/Post/PostCellView.swift
+++ b/Views/Components/Post/PostCellView.swift
@@ -82,7 +82,7 @@ private struct PostCellHeader: View {
                 }
             }
             .frame(width: 48, height: 48)
-            .background(Color(.systemGray5))
+            .background(Color.systemGray5)
             .clipShape(Circle())
 
             VStack(alignment: .leading, spacing: 4) {
@@ -176,7 +176,7 @@ private struct RemoteMediaView: View {
     private func placeholderView(symbolName: String) -> some View {
         ZStack {
             RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                .fill(Color(.systemGray6))
+                .fill(Color.systemGray6)
 
             Image(systemName: symbolName)
                 .font(.title2)
@@ -231,7 +231,7 @@ private struct LinkPreviewView: View {
         .padding(14)
         .background(
             RoundedRectangle(cornerRadius: 18, style: .continuous)
-                .fill(Color(.systemGray6))
+                .fill(Color.systemGray6)
         )
     }
 }

--- a/Views/Components/SuggestStory/SuggestStoryView.swift
+++ b/Views/Components/SuggestStory/SuggestStoryView.swift
@@ -78,7 +78,7 @@ private struct SuggestStoryCell: View {
         Button(action: onTap) {
             ZStack {
                 RoundedRectangle(cornerRadius: 18, style: .continuous)
-                    .fill(Color(.systemGray6))
+                    .fill(Color.systemGray6)
 
                 if let url = story.thumbnailURL {
                     AsyncImage(url: url) { phase in

--- a/Views/Video/VideoTabView.swift
+++ b/Views/Video/VideoTabView.swift
@@ -50,21 +50,21 @@ private struct VideoCardView: View {
                     switch phase {
                     case .empty:
                         Circle()
-                            .fill(Color(.systemGray5))
+                            .fill(Color.systemGray5)
                     case .success(let image):
                         image
                             .resizable()
                             .scaledToFill()
                     case .failure:
                         Circle()
-                            .fill(Color(.systemGray5))
+                            .fill(Color.systemGray5)
                             .overlay(
                                 Image(systemName: "person.fill")
                                     .foregroundStyle(.secondary)
                             )
                     @unknown default:
                         Circle()
-                            .fill(Color(.systemGray5))
+                            .fill(Color.systemGray5)
                     }
                 }
                 .frame(width: 36, height: 36)
@@ -92,7 +92,7 @@ private struct VideoThumbnail: View {
 
             ZStack {
                 roundedRect
-                    .fill(Color(.systemGray5))
+                    .fill(Color.systemGray5)
 
                 AsyncImage(url: url) { phase in
                     switch phase {


### PR DESCRIPTION
## Summary
- add a SwiftUI Color extension that recreates the system gray palette values
- refactor views to use the new SwiftUI colors instead of UIKit systemGray constants

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68df9faa12c0832ebd6ffc574ab6dc26